### PR TITLE
Allow bounded queues in Client

### DIFF
--- a/src/test/scala/github/gphat/censorinus/ClientSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/ClientSpec.scala
@@ -1,40 +1,39 @@
 package github.gphat.censorinus
 
+import java.util.concurrent.{ LinkedBlockingQueue, TimeUnit }
 import org.scalatest._
+import org.scalatest.concurrent.Eventually
 import scala.collection.mutable.ArrayBuffer
 import github.gphat.censorinus.statsd.Encoder
 
-class TestSender extends MetricSender {
-  val buffer = new ArrayBuffer[String]()
+object TestSender {
+  def defaultDeadline: Long = System.currentTimeMillis + 1000
+}
 
-  def awaitMessages(n: Int): List[String] = {
-    var i = 0
-    while (i < 100 && buffer.size < n) {
-      Thread.sleep(10)
-      i += 1
-    }
+class TestSender(val maxMessages: Int = Int.MaxValue) extends MetricSender {
+  val buffer: LinkedBlockingQueue[String] =
+    new LinkedBlockingQueue(maxMessages)
 
-    this.synchronized {
-      if(buffer.size < n) {
-        throw new Exception("didn't get enough messages!")
-      } else {
-        buffer.toList
-      }
+  def awaitMessage(deadline: Long = TestSender.defaultDeadline): String = {
+    val duration = math.max(5, deadline - System.currentTimeMillis)
+    Option(buffer.poll(duration, TimeUnit.MILLISECONDS)).getOrElse {
+      throw new Exception("didn't get enough messages in time!")
     }
   }
 
-  def clear = buffer.clear
+  def awaitMessages(n: Int, deadline: Long = TestSender.defaultDeadline): List[String] =
+    List.fill(n)(awaitMessage(deadline))
 
-  def send(message: String): Unit = this.synchronized {
-    buffer.append(message)
+  def send(message: String): Unit = {
+    if (!buffer.offer(message, 1, TimeUnit.MINUTES)) {
+      throw new Exception("too much time required for test")
+    }
   }
 
   def shutdown: Unit = ()
-
-  def getBuffer = buffer
 }
 
-class ClientSpec extends FlatSpec with Matchers {
+class ClientSpec extends FlatSpec with Matchers with Eventually {
 
   "ClientSpec" should "deal with gauges" in {
     val sender = new TestSender()
@@ -42,6 +41,39 @@ class ClientSpec extends FlatSpec with Matchers {
     client.enqueue(Metric(name = "foobar", value = "1.0", metricType = "g"))
     val msg :: Nil = sender.awaitMessages(1)
     msg should be ("foobar:1.0|g")
+    client.shutdown
+  }
+
+  it should "not enqueue metrics when queue is full" in {
+    // We'll send 2 messages successfully, then block in the sender.
+    val sender = new TestSender(2)
+    // After the sender blocks, we'll still be able to queue up 1 more message.
+    val client = new Client(encoder = Encoder, sender = sender, maxQueueSize = Some(1))
+
+    client.enqueue(Metric(name = "a", value = "1.0", metricType = "g"))
+    eventually { client.queue.size should be (0) } // Wait for queue to empty.
+    client.enqueue(Metric(name = "b", value = "2.0", metricType = "g"))
+    eventually { client.queue.size should be (0) } // Wait for queue to empty.
+    client.enqueue(Metric(name = "c", value = "3.0", metricType = "g"))
+
+    // All good. The sender's buffer is full and so is the client's queue.
+    // This metric will be dropped instead of queued up.
+    client.enqueue(Metric(name = "d", value = "4.0", metricType = "g"))
+
+    // We drain the buffer and the client's queue.
+    val messages = sender.awaitMessages(3)
+    messages should be (List("a:1.0|g", "b:2.0|g", "c:3.0|g"))
+
+    // Now that things are empty again, this will flow through.
+    client.enqueue(Metric(name = "e", value = "5.0", metricType = "g"))
+    val msg = sender.awaitMessage()
+    msg should be ("e:5.0|g")
+
+    // A bit flakey, since we set a short time limit, but this is just a sanity
+    // check that we have had no further messages sent, excluding the
+    // possibility that 'e' and 'd' were just reordered.
+    an [Exception] should be thrownBy sender.awaitMessage(System.currentTimeMillis + 50)
+
     client.shutdown
   }
 }

--- a/src/test/scala/github/gphat/censorinus/SamplingSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/SamplingSpec.scala
@@ -11,14 +11,14 @@ class SamplingSpec extends FlatSpec with Matchers {
   "Client" should "sample things" in {
     val client = new Client(encoder = Encoder, sender = s, asynchronous = false)
     client.enqueue(Metric(name = "foobar", value = "1.0", metricType = "g"), sampleRate = 0.0)
-    s.getBuffer.size should be (0)
+    s.buffer.size should be (0)
     client.shutdown
   }
 
   it should "bypass the sampler and send it anyway" in {
     val client = new Client(encoder = Encoder, sender = s, asynchronous = false)
     client.enqueue(Metric(name = "foobar", value = "1.0", metricType = "g"), sampleRate = 0.0, bypassSampler = true)
-    s.getBuffer.size should be (1)
+    s.buffer.size should be (1)
     client.shutdown
   }
 

--- a/src/test/scala/github/gphat/censorinus/SynchronySpec.scala
+++ b/src/test/scala/github/gphat/censorinus/SynchronySpec.scala
@@ -7,16 +7,18 @@ import github.gphat.censorinus.statsd.Encoder
 class SynchronySpec extends FlatSpec with Matchers with Eventually {
 
   "Client" should "deal with gauges" in {
-    val s = new TestSender()
+    val s = new TestSender(1)
     val client = new Client(encoder = Encoder, sender = s)
 
+    // Queue up a message in the sender to ensure we can't publish yet.
+    s.buffer.offer("BOO!")
+    s.buffer.size should be (1)
+
     client.enqueue(Metric(name = "foobar", value = "1.0", metricType = "g"))
-    s.getBuffer.size should be (0) // Won't be there yet
-    eventually {
-      val m = s.getBuffer(0)
-      m should include ("foobar")
-      client.shutdown
-    }
+    s.buffer.size should be (1) // New metric won't be there yet
+    s.awaitMessage() should be ("BOO!")
+    s.awaitMessage() should include ("foobar")
+    client.shutdown
   }
 
   it should "be synchronous" in {
@@ -24,7 +26,7 @@ class SynchronySpec extends FlatSpec with Matchers with Eventually {
     val client = new Client(encoder = Encoder, sender = s, asynchronous = false)
 
     client.enqueue(Metric(name = "foobar", value = "1.0", metricType = "g"))
-    val m = s.getBuffer(0)
+    val m = s.buffer.poll()
     m should include ("foobar")
     client.shutdown
   }


### PR DESCRIPTION
This is just to make me feel better really, but it let's us set an upper limit on the amount of messages we'll allow to be queued up. I had to refactor the `TestSender` a bit too, so I could simulate a slow `Sender`.
