### PR TITLE
Made the documentation reflect reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Censorinus is a Scala \*StatsD client with multiple personalities.
 
 ```scala
 // Add the Dep
-libraryDependencies += "github.gphat" %% "censorinus" % "2.0.2"
+libraryDependencies += "com.github.gphat" %% "censorinus" % "2.0.2"
 
 // And a the resolver
 resolvers += "gphat" at "https://raw.github.com/gphat/mvn-repo/master/releases/",

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ that takes a `Seq[String]` of tags.
 ```scala
 import github.gphat.censorinus.DogStatsDClient
 
-val c = new DogStatsDClient(host = "some.host", port = 8125)
+val c = new DogStatsDClient(hostname = "some.host", port = 8125)
 
 // Not gonna list 'em all since the methods are the same, but allow tags!
 c.counter(name = "foo.count", value = 2, tags = Seq("foo:bar"))
@@ -71,7 +71,7 @@ If all your metrics start with a common string like a service or team name then
 you can safe yourself by using prefixes when instantiating a client:
 
 ```scala
-val c = new DogStatsDClient(host = "some.host", port = 8125, prefix = "mycoolapp")
+val c = new DogStatsDClient(hostname = "some.host", port = 8125, prefix = "mycoolapp")
 c.counter(name = "foo.count") // Resulting metric will be mycoolapp.foo.count
 ```
 


### PR DESCRIPTION
your maven repo has this binary under /com, so the documentation has been pointing to the wrong place since version 1. This should fix it.
