### PR TITLE
Plumb maxQueueSize through both contructors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ organization := "com.github.gphat"
 
 name := "censorinus"
 
-version := "2.0.2"
-
 scalaVersion := "2.11.7"
 crossScalaVersions := Seq("2.10.6", "2.11.8")
 

--- a/src/main/scala/github/gphat/censorinus/DogStatsDClient.scala
+++ b/src/main/scala/github/gphat/censorinus/DogStatsDClient.scala
@@ -21,14 +21,16 @@ class DogStatsDClient(
   prefix: String = "",
   defaultSampleRate: Double = 1.0,
   asynchronous: Boolean = true,
-  floatFormat: String = "%.8f"
+  floatFormat: String = "%.8f",
+  maxQueueSize: Option[Int] = None
 ) extends Client(
   sender = new UDPSender(hostname = hostname, port = port),
   encoder = Encoder,
   prefix = prefix,
   defaultSampleRate = defaultSampleRate,
   asynchronous = asynchronous,
-  floatFormat = floatFormat
+  floatFormat = floatFormat,
+  maxQueueSize = maxQueueSize
 ) {
   /** Emit a counter metric.
     * @param name The name of the metric


### PR DESCRIPTION
This parameter was added in a previous commit, but since it wasn't exposed in the `DogStatsDClient`, it wasn't possible for users to configure.
