### PR TITLE
Update docs and clean up `take` code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,18 +104,18 @@ c.counter(name = "foo.count") // Resulting metric will be mycoolapp.foo.count
 
 # Asynchronous (default behavior)
 
-Metrics are locally queued up — via a BlockingQueue — and emptied out in another
-thread with a 10ms delay on empty.
+Metrics are locally queued via a BlockingQueue and emptied out in single
+ThreadExecutor thread. Messages are sent as quickly as the blocking `take` in
+that thread can fetch an item from the head of the queue.
 
 You may provide a `maxQueueSize` when creating a client. Doing so will prevent
 the accidental unbounded growth of the metric send queue. If the limit is reached
 then new metrics **will be dropped** until the queue has room again. Logs will
 be emitted in this case.
 
-**Note:** For asynchronous use there is a ScheduledThreadExecutor fired up. You
-can call `c.shutdown` to forcibly end things. The threads in this executor are
-flagged as deaemon threads so ending your program will cause any unsent metrics
-to be lost.
+**Note:** You can call `c.shutdown` to forcibly end things. The threads in this
+executor are flagged as deaemon threads so ending your program will cause any
+unsent metrics to be lost.
 
 # Synchronous
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ c.counter(name = "foo.count") // Resulting metric will be mycoolapp.foo.count
 Metrics are locally queued up — via a BlockingQueue — and emptied out in another
 thread with a 10ms delay on empty.
 
+You may provide a `maxQueueSize` when creating a client. Doing so will prevent
+the accidental unbounded growth of the metric send queue. If the limit is reached
+then new metrics **will be dropped** until the queue has room again. Logs will
+be emitted in this case.
+
 **Note:** For asynchronous use there is a ScheduledThreadExecutor fired up. You
 can call `c.shutdown` to forcibly end things. The threads in this executor are
 flagged as deaemon threads so ending your program will cause any unsent metrics
@@ -145,13 +150,6 @@ You can also supply a `bypassSampler = true` argument to any of the client's
 methods to send the metric regardless. Note that the sample rate will *also* be
 sent. This is a convenience method to allow you to do your own sampling and pass
 that along to this library.
-
-## Max Queue Size
-
-You may provide a `maxQueueSize` when creating a client. Doing so will prevent
-the accidental unbounded growth of the metric send queue. If the limit is reached
-then new metrics **will be dropped** until the queue has room again. Logs will
-be emitted in this case.
 
 # Notes
 

--- a/src/main/scala/github/gphat/censorinus/Client.scala
+++ b/src/main/scala/github/gphat/censorinus/Client.scala
@@ -1,11 +1,9 @@
 package github.gphat.censorinus
 
 import java.text.DecimalFormat
-import java.util.ArrayList
 import java.util.concurrent._
 import java.util.logging.Logger
 
-import scala.collection.JavaConversions._
 import scala.util.control.NonFatal
 
 /** A Censorinus client! You should create one of these and reuse it across

--- a/src/main/scala/github/gphat/censorinus/Client.scala
+++ b/src/main/scala/github/gphat/censorinus/Client.scala
@@ -57,14 +57,7 @@ class Client(
   executor.foreach { ex =>
     val task = new Runnable {
       def tick(): Unit = try {
-        Option(queue.take).map({ metric =>
-          val buff = new ArrayList[Metric]()
-          buff.add(metric)
-          queue.drainTo(buff)
-          buff.foreach({ m =>
-            send(m)
-          })
-        })
+        Option(queue.take).foreach(send)
       } catch {
         case _: InterruptedException => Thread.currentThread.interrupt
         case NonFatal(exception) => {

--- a/src/main/scala/github/gphat/censorinus/Client.scala
+++ b/src/main/scala/github/gphat/censorinus/Client.scala
@@ -87,7 +87,7 @@ class Client(
       if(asynchronous) {
         // Queue it up! Leave encoding for later so get we back as soon as we can.
         if (!queue.offer(metric)) {
-          log.warning("Unable to enqueue metric, queue is full. Metric was dropped." +
+          log.warning("Unable to enqueue metric, queue is full. Metric was dropped. " +
             "If this is during steady state, consider decreasing the defaultSampleRate, " +
             "but if this periodic, consider increasing the maxQueueSize.")
         }

--- a/src/main/scala/github/gphat/censorinus/Client.scala
+++ b/src/main/scala/github/gphat/censorinus/Client.scala
@@ -51,7 +51,7 @@ class Client(
   }
 
   // If we are running asynchronously, then kick off our long-running task that
-  // repeatedly polls the queue and send the available metrics down the road.
+  // repeatedly polls the queue and sends the available metrics down the road.
   executor.foreach { ex =>
     val task = new Runnable {
       def tick(): Unit = try {

--- a/src/main/scala/github/gphat/censorinus/example/Benchmark.scala
+++ b/src/main/scala/github/gphat/censorinus/example/Benchmark.scala
@@ -1,0 +1,35 @@
+package github.gphat.censorinus.example
+
+import github.gphat.censorinus.DogStatsDClient
+
+import java.util.UUID
+import scala.util.Random
+
+object Benchmark {
+
+  def main(args: Array[String]): Unit = {
+    val client = new DogStatsDClient(asynchronous=true, defaultSampleRate = 1, maxQueueSize = Some(10000))
+
+    val iterations = 10
+    var tot = 0L
+    Range(start = 0, end = iterations - 1, step = 1).foreach({ h =>
+      tot += time {
+        Range(start = 0, end = 10050, step = 1).foreach({ h =>
+          client.increment("foo.bar.baz_counter", 1, tags = Seq("gorch:flurb"))
+        })
+        while(client.queue.size > 0) {
+          // Nothing
+        }
+      }
+    })
+    println("Elapsed time: " + tot + "ns, " + (tot / iterations) + "ns average")
+    client.shutdown
+  }
+
+  def time[R](block: => Unit): Long = {
+    val t0 = System.nanoTime()
+    block
+    val t1 = System.nanoTime()
+    t1 - t0
+  }
+}


### PR DESCRIPTION
### What's this PR do?

Cleans up some code — but doesn't change any behavior — and improves documentation around the async stuff.
### Motivation

In a production service the choice of 1,000 for a `maxQueueSize` was too small. We've improved the error messaging and documentation.
### Notes

I did some benchmarking with a "clear the whole queue with one `drainTo`" and it didn't seem to make any real difference. I suspect that if we could batch `send` — which DogStatsD does support, but we have to deal with MTU worries — it would be significantly faster to drain and send a collection in chunks.
