### PR TITLE
Swallow exceptions to prevent breakage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Censorinus is a Scala \*StatsD client with multiple personalities.
 * [DogStatsD Compatibility](http://docs.datadoghq.com/guides/dogstatsd/#datagram-format)
 * UDP only
 * Option for max queue size when using asynchronous.
+* "Swallows" relevant exceptions (IO, Unresolveable) by **default** to prevent runtime errors breaking your service
 
 # Using It
 
@@ -154,3 +155,4 @@ that along to this library.
 # Notes
 
 * All metric names and such are encoded as UTF-8.
+* If you prefer to catch your own exceptions or log them somehow when failing to deliver or resolve the upstream target, look for `allowExceptions` on your client of choice and set to true!

--- a/src/main/scala/github/gphat/censorinus/DogStatsDClient.scala
+++ b/src/main/scala/github/gphat/censorinus/DogStatsDClient.scala
@@ -26,7 +26,8 @@ object DogStatsDClient {
   * @param prefix A prefix to add to all metric names. A period will be added to the end, resulting in prefix.metricname.
   * @param defaultSampleRate A sample rate default to be used for all metric methods. Defaults to 1.0
   * @param asynchronous True if you want the client to asynch, false for blocking!
-  * @param floatFormat Allows control of the precision of the double output via strings from [[java.util.Formatter]]. Defaults to "%.8f".
+  * @param maxQueueSize Maximum amount of metrics allowed to be queued at a time.
+  * @param allowExceptions If false, any `SocketException`s will be swallowed silently
   */
 class DogStatsDClient(
   hostname: String = "localhost",
@@ -34,9 +35,10 @@ class DogStatsDClient(
   prefix: String = "",
   defaultSampleRate: Double = 1.0,
   asynchronous: Boolean = true,
-  maxQueueSize: Option[Int] = None
+  maxQueueSize: Option[Int] = None,
+  allowExceptions: Boolean = false
 ) extends Client(
-  sender = new UDPSender(hostname = hostname, port = port),
+  sender = new UDPSender(hostname = hostname, port = port, allowExceptions = allowExceptions),
   encoder = Encoder,
   prefix = prefix,
   defaultSampleRate = defaultSampleRate,

--- a/src/main/scala/github/gphat/censorinus/StatsDClient.scala
+++ b/src/main/scala/github/gphat/censorinus/StatsDClient.scala
@@ -14,16 +14,17 @@ import scala.util.Random
   * @param prefix A prefix to add to all metric names. A period will be added to the end, resulting in prefix.metricname.
   * @param defaultSampleRate A sample rate default to be used for all metric methods. Defaults to 1.0
   * @param asynchronous True if you want the client to asynch, false for blocking!
-  * @param floatFormat Allows control of the precision of the double output via strings from [[java.util.Formatter]]. Defaults to "%.8f".
+  * @param allowExceptions If false, any `SocketException`s will be swallowed silently
   */
 class StatsDClient(
   hostname: String = "localhost",
   port: Int = MetricSender.DEFAULT_STATSD_PORT,
   prefix: String = "",
   defaultSampleRate: Double = 1.0,
-  asynchronous: Boolean = true
+  asynchronous: Boolean = true,
+  allowExceptions: Boolean = false
 ) extends Client(
-  sender = new UDPSender(hostname = hostname, port = port),
+  sender = new UDPSender(hostname = hostname, port = port, allowExceptions = allowExceptions),
   encoder = Encoder,
   prefix = prefix,
   defaultSampleRate = defaultSampleRate,

--- a/src/main/scala/github/gphat/censorinus/UDPSender.scala
+++ b/src/main/scala/github/gphat/censorinus/UDPSender.scala
@@ -1,16 +1,31 @@
 package github.gphat.censorinus
 
-import java.net.InetSocketAddress
+import java.net.{InetSocketAddress,SocketException}
 import java.nio.ByteBuffer
+import java.nio.channels.UnresolvedAddressException
 import java.nio.channels.DatagramChannel
 import java.nio.charset.StandardCharsets
 
-class UDPSender(hostname: String = "localhost", port: Int = MetricSender.DEFAULT_STATSD_PORT) extends MetricSender {
+class UDPSender(
+  hostname: String = "localhost",
+  port: Int = MetricSender.DEFAULT_STATSD_PORT,
+  allowExceptions: Boolean = false
+) extends MetricSender {
 
   lazy val clientSocket = DatagramChannel.open.connect(new InetSocketAddress(hostname, port))
 
   def send(message: String): Unit = {
-    clientSocket.write(ByteBuffer.wrap(message.getBytes(StandardCharsets.UTF_8)))
+    try {
+      clientSocket.write(ByteBuffer.wrap(message.getBytes(StandardCharsets.UTF_8)))
+    } catch {
+      case se @ (_ : SocketException | _ : UnresolvedAddressException) => {
+        // If were allowing exceptions, rethrow the one we just got, otherwise
+        // we'll do nothing and swallow it.
+        if(allowExceptions) {
+          throw se
+        }
+      }
+    }
   }
 
   def shutdown: Unit = clientSocket.close

--- a/src/main/scala/github/gphat/censorinus/UDPSender.scala
+++ b/src/main/scala/github/gphat/censorinus/UDPSender.scala
@@ -19,8 +19,9 @@ class UDPSender(
       clientSocket.write(ByteBuffer.wrap(message.getBytes(StandardCharsets.UTF_8)))
     } catch {
       case se @ (_ : SocketException | _ : UnresolvedAddressException) => {
-        // If were allowing exceptions, rethrow the one we just got, otherwise
-        // we'll do nothing and swallow it.
+        // Check if we're allowing exceptions and rethrow if so. We didn't use
+        // a guard on the case because then we'd need a second case to catch
+        // the !allowExceptions case!
         if(allowExceptions) {
           throw se
         }

--- a/src/test/scala/github/gphat/censorinus/UDPSenderSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/UDPSenderSpec.scala
@@ -13,7 +13,7 @@ class UDPSenderSpec extends FlatSpec with Matchers {
 
   it should "swallow errors" in {
     // Guessing this port won't be used? :)
-    val u = new UDPSender(hostname = "fart.example.com", port = 8126, allowExceptions = false)
+    val u = new UDPSender(hostname = "127.0.0.1789", port = 8126, allowExceptions = false)
     u.send("abc")
   }
 }

--- a/src/test/scala/github/gphat/censorinus/UDPSenderSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/UDPSenderSpec.scala
@@ -1,0 +1,19 @@
+package github.gphat.censorinus
+
+import org.scalatest._
+import java.nio.channels.UnresolvedAddressException
+
+class UDPSenderSpec extends FlatSpec with Matchers {
+
+  "UDPSender" should "emit errors" in {
+    // Guessing this port won't be used? :)
+    val u = new UDPSender(hostname = "127.0.0.1789", port = 8126, allowExceptions = true)
+    an [UnresolvedAddressException] should be thrownBy u.send("abc")
+  }
+
+  it should "swallow errors" in {
+    // Guessing this port won't be used? :)
+    val u = new UDPSender(hostname = "fart.example.com", port = 8126, allowExceptions = false)
+    u.send("abc")
+  }
+}


### PR DESCRIPTION
### What's this PR do?

Adds an option — on by default — that silently swallows exceptions related to sending metrics.
### Motivation

We should **not** cause exceptions that break applications. The contract for *StatsD clients is tacitly to never do this.
