### PR TITLE
Properly escape newlines in service checks and events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.1.4] - 2016-10-19
+
+## Fixed
+* Newlines in events and service check are now properly escaped.
+
 ## [2.1.3] - 2016-07-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Censorinus is available on Maven Central.
 
 ```scala
 // Add the Dep for Scala 2.11
-libraryDependencies += "com.github.gphat" % "censorinus_2.11" % "2.1.3"
+libraryDependencies += "com.github.gphat" % "censorinus_2.11" % "2.1.4"
 // Or for Scala 2.10
-libraryDependencies += "com.github.gphat" % "censorinus_2.10" % "2.1.3"
+libraryDependencies += "com.github.gphat" % "censorinus_2.10" % "2.1.4"
 ```
 
 You should create a single instance of a client reuse it throughout your

--- a/src/main/scala/github/gphat/censorinus/dogstatsd/Encoder.scala
+++ b/src/main/scala/github/gphat/censorinus/dogstatsd/Encoder.scala
@@ -62,7 +62,7 @@ object Encoder extends MetricEncoder {
 
   def encodeEvent(sc: EventMetric): String = {
     val sb = new StringBuilder()
-    val escapedText = sc.text.replace("\n", "\\\\n")
+    val escapedText = escapeDogstatsd(sc.text)
     sb.append("_e{")
     sb.append(sc.name.length.toString)
     sb.append(",")
@@ -139,9 +139,13 @@ object Encoder extends MetricEncoder {
     encodeTags(sb, sc.tags)
     sc.message.foreach({ m =>
       sb.append("|m:")
-      sb.append(m.replace("\n", "\\\\n"))
+      sb.append(escapeDogstatsd(m))
     })
     sb.toString
+  }
+
+  private def escapeDogstatsd(value: String): String = {
+    value.replace("\n", "\\\\n")
   }
 
   // Encodes the base metric and tags only. This covers most metrics.

--- a/src/main/scala/github/gphat/censorinus/dogstatsd/Encoder.scala
+++ b/src/main/scala/github/gphat/censorinus/dogstatsd/Encoder.scala
@@ -62,14 +62,15 @@ object Encoder extends MetricEncoder {
 
   def encodeEvent(sc: EventMetric): String = {
     val sb = new StringBuilder()
+    val escapedText = sc.text.replace("\n", "\\\\n")
     sb.append("_e{")
     sb.append(sc.name.length.toString)
     sb.append(",")
-    sb.append(sc.text.length.toString)
+    sb.append(escapedText.length.toString)
     sb.append("}:")
     sb.append(sc.name)
     sb.append("|")
-    sb.append(sc.text)
+    sb.append(escapedText)
     sc.timestamp.foreach({ d =>
       sb.append("|d:")
       sb.append(d.toString)
@@ -138,7 +139,7 @@ object Encoder extends MetricEncoder {
     encodeTags(sb, sc.tags)
     sc.message.foreach({ m =>
       sb.append("|m:")
-      sb.append(m)
+      sb.append(m.replace("\n", "\\\\n"))
     })
     sb.toString
   }

--- a/src/test/scala/github/gphat/censorinus/DogStatsDEncoderSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/DogStatsDEncoderSpec.scala
@@ -60,6 +60,15 @@ class DogStatsDEncoderSpec extends FlatSpec with Matchers {
     Encoder.encode(m).get should be ("_sc|foobar|0|d:%d|h:fart|#foo:bar|m:wheeee".format(now))
   }
 
+  it should "encode service checks with newlines" in {
+    val now = System.currentTimeMillis() / 1000L
+    val m = ServiceCheckMetric(
+      name = "foobar", status = DogStatsDClient.SERVICE_CHECK_OK, tags = Array("foo:bar"),
+      hostname = Some("fart"), timestamp = Some(now), message = Some("hello\nworld")
+    )
+    Encoder.encode(m).get should be ("_sc|foobar|0|d:%d|h:fart|#foo:bar|m:hello\\\\nworld".format(now))
+  }
+
   it should "encode events" in {
     val now = System.currentTimeMillis() / 1000L
     val m = EventMetric(
@@ -70,5 +79,18 @@ class DogStatsDEncoderSpec extends FlatSpec with Matchers {
       alertType = Some(DogStatsDClient.EVENT_ALERT_TYPE_ERROR)
     )
     Encoder.encode(m).get should be ("_e{6,14}:foobar|derp derp derp|d:%d|h:fart|k:agg_key|p:low|s:user|t:error|#foo:bar".format(now))
+  }
+
+  it should "encode events with newlines" in {
+    val now = System.currentTimeMillis() / 1000L
+    val m = EventMetric(
+      name = "foobar", text = "derp derp\nderp", tags = Array("foo:bar"),
+      hostname = Some("fart"), timestamp = Some(now), aggregationKey = Some("agg_key"),
+      priority = Some(DogStatsDClient.EVENT_PRIORITY_LOW),
+      sourceTypeName = Some("user"),
+      alertType = Some(DogStatsDClient.EVENT_ALERT_TYPE_ERROR)
+    )
+    println(Encoder.encode(m))
+    Encoder.encode(m).get should be ("_e{6,16}:foobar|derp derp\\\\nderp|d:%d|h:fart|k:agg_key|p:low|s:user|t:error|#foo:bar".format(now))
   }
 }

--- a/src/test/scala/github/gphat/censorinus/DogStatsDEncoderSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/DogStatsDEncoderSpec.scala
@@ -90,7 +90,6 @@ class DogStatsDEncoderSpec extends FlatSpec with Matchers {
       sourceTypeName = Some("user"),
       alertType = Some(DogStatsDClient.EVENT_ALERT_TYPE_ERROR)
     )
-    println(Encoder.encode(m))
     Encoder.encode(m).get should be ("_e{6,16}:foobar|derp derp\\\\nderp|d:%d|h:fart|k:agg_key|p:low|s:user|t:error|#foo:bar".format(now))
   }
 }


### PR DESCRIPTION
### What's this PR do?

Escapes newlines in Events and Service Checks
### Motivation

[DogStatsD's spec](http://docs.datadoghq.com/guides/dogstatsd/#events-1) says newlines are supported, but [the code says that they must be escaped](https://github.com/DataDog/dd-agent/blob/master/aggregator.py#L506). To that end, let's escape them.
### Notes

This changes the length of the string, so that's in there too. Test are added for both primitives and their newlines.
