### PR TITLE
Only log every nth warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,19 @@ methods to send the metric regardless. Note that the sample rate will *also* be
 sent. This is a convenience method to allow you to do your own sampling and pass
 that along to this library.
 
+## Threshold-based
+
+You can supply an optional `samplingThreshold` to the client that specifies a
+ratio at which the client will begin sampling, overriding any sampling value
+in the metric itself. When the `samplingThreshold` is met it is inverted by
+subtracting the ratio from 1.0. (e.g. a `samplingThreshold` of `.6` will result
+in a value of `.4`) and all incoming metrics sampled using this dynamic rate.
+
+This is a rather naive mechanism for sampling and it applies universally
+regardless of the desired sampling of the incoming metric. It is provided as an
+improvement over situations when the `maxQueueSize` is met and **no** metrics
+are emitted.
+
 # Notes
 
 * All metric names and such are encoded as UTF-8.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ that thread can fetch an item from the head of the queue.
 You may provide a `maxQueueSize` when creating a client. Doing so will prevent
 the accidental unbounded growth of the metric send queue. If the limit is reached
 then new metrics **will be dropped** until the queue has room again. Logs will
-be emitted in this case.
+be emitted in this case for every `consecutiveDropWarnThreshold` drops. You can
+adjust this when instantiating a client.
 
 **Note:** You can call `c.shutdown` to forcibly end things. The threads in this
 executor are flagged as deaemon threads so ending your program will cause any
@@ -152,19 +153,6 @@ You can also supply a `bypassSampler = true` argument to any of the client's
 methods to send the metric regardless. Note that the sample rate will *also* be
 sent. This is a convenience method to allow you to do your own sampling and pass
 that along to this library.
-
-## Threshold-based
-
-You can supply an optional `samplingThreshold` to the client that specifies a
-ratio at which the client will begin sampling, overriding any sampling value
-in the metric itself. When the `samplingThreshold` is met it is inverted by
-subtracting the ratio from 1.0. (e.g. a `samplingThreshold` of `.6` will result
-in a value of `.4`) and all incoming metrics sampled using this dynamic rate.
-
-This is a rather naive mechanism for sampling and it applies universally
-regardless of the desired sampling of the incoming metric. It is provided as an
-improvement over situations when the `maxQueueSize` is met and **no** metrics
-are emitted.
 
 # Notes
 

--- a/src/main/scala/github/gphat/censorinus/Client.scala
+++ b/src/main/scala/github/gphat/censorinus/Client.scala
@@ -26,7 +26,7 @@ class Client(
   asynchronous: Boolean = true,
   maxQueueSize: Option[Int] = None,
   consecutiveDropWarnThreshold: Long = 1000,
-  consecutiveDroppedMetrics: AtomicLong = new AtomicLong(0)
+  val consecutiveDroppedMetrics: AtomicLong = new AtomicLong(0)
 ) {
   private[this] val log: Logger = Logger.getLogger(classOf[Client].getName)
 

--- a/src/test/scala/github/gphat/censorinus/ClientSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/ClientSpec.scala
@@ -61,6 +61,10 @@ class ClientSpec extends FlatSpec with Matchers with Eventually {
     // This metric will be dropped instead of queued up.
     client.enqueue(GaugeMetric(name = "b", value = 4.0))
 
+    // All good. The sender's buffer is full and so is the client's queue.
+    // This metric will be dropped instead of queued up.
+    client.enqueue(GaugeMetric(name = "b", value = 4.0))
+
     // // We drain the buffer and the client's queue.
     // val messages = sender.awaitMessages(3)
     client.queue.peek should be (GaugeMetric(name = "a", value = 1.0))
@@ -74,4 +78,6 @@ class ClientSpec extends FlatSpec with Matchers with Eventually {
 
     client.queue.size should be (1)
   }
+
+  it should ""
 }

--- a/src/test/scala/github/gphat/censorinus/ClientSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/ClientSpec.scala
@@ -65,6 +65,8 @@ class ClientSpec extends FlatSpec with Matchers with Eventually {
     // This metric will be dropped instead of queued up.
     client.enqueue(GaugeMetric(name = "b", value = 4.0))
 
+    client.consecutiveDroppedMetrics.get should be (2)
+
     // // We drain the buffer and the client's queue.
     // val messages = sender.awaitMessages(3)
     client.queue.peek should be (GaugeMetric(name = "a", value = 1.0))
@@ -78,6 +80,4 @@ class ClientSpec extends FlatSpec with Matchers with Eventually {
 
     client.queue.size should be (1)
   }
-
-  it should ""
 }


### PR DESCRIPTION
It's chunderous to emit every single dropped metric, so default to only logging the first and then every 1000th *consecutive* drop. This could happen more often than intended if someone is hovering near the cap, but that seems an improvement over the current state.