### PR TITLE
Avoid an allocation and lambda in a loop

### DIFF
--- a/src/main/scala/github/gphat/censorinus/MetricEncoder.scala
+++ b/src/main/scala/github/gphat/censorinus/MetricEncoder.scala
@@ -8,7 +8,7 @@ import github.gphat.censorinus._
 trait MetricEncoder {
 
   /**
-   * Returns an encoded version of the metirc, suitable for sending over the
+   * Returns an encoded version of the metric, suitable for sending over the
    * wire. If the metric type is not supported, then `None` is returned.
    */
   def encode(metric: Metric): Option[String]


### PR DESCRIPTION
Inside the sending loop, avoid one allocation and don't use foreach (which also creates another allocation of a new lambda).

This will probably make a small, but measurable increase in throughput.