### PR TITLE
Remove unnecessary runtime dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-   - 2.12.2
+   - 2.12.5
 jdk:
   - oraclejdk8
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: scala
 scala:
+   - 2.11.12
    - 2.12.5
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ organization := "com.github.gphat"
 
 name := "censorinus"
 
-scalaVersion := "2.12.4"
-crossScalaVersions := Seq("2.11.11", "2.12.2")
+scalaVersion := "2.12.5"
+crossScalaVersions := Seq("2.11.12", "2.12.5")
 
 scalacOptions ++= Seq(
  "-encoding", "UTF-8",
@@ -24,9 +24,9 @@ scalacOptions ++= Seq(
 
 resolvers ++= Seq("snapshots", "releases").map(Resolver.sonatypeRepo)
 
-libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.3" % "test"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % "test"
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
+libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.5" % Test
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.5" % Test
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,7 @@ resolvers ++= Seq("snapshots", "releases").map(Resolver.sonatypeRepo)
 
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.3" % "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % "test"
-libraryDependencies += "com.thesamet.scalapb" %% "scalapb-runtime" % "0.7.0-rc6"
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.4"
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
A recent release introduced two runtime dependencies that seem to be unnecessary:

* scalapb-runtime: doesn't seem to be used anywhere, no idea why it's here?
* scalacheck: used but should be scoped `test`.

 This is a little annoying in e.g. the bazel world, where we end up with a bunch of new `3rdparty` directories for each of these runtime deps and their transitive dependencies.

While I was here I went ahead and bumped a few patch versions and build stuff that doesn't break bincompat.

r? @gphat @tixxit