### PR TITLE
fix StatsDClient.decrement

### DIFF
--- a/src/main/scala/github/gphat/censorinus/StatsDClient.scala
+++ b/src/main/scala/github/gphat/censorinus/StatsDClient.scala
@@ -54,7 +54,7 @@ class StatsDClient(
     */
   def decrement(
     name: String,
-    value: Double = 1,
+    value: Double = -1,
     sampleRate: Double = defaultSampleRate,
     bypassSampler: Boolean = false
   ): Unit = enqueue(


### PR DESCRIPTION
The docs say `decrement` has a default value of -1, but it is actually 1, which made the method the exact same as `increment`.