### PR TITLE
remove (possibly?) errant println

### DIFF
--- a/src/main/scala/github/gphat/censorinus/dogstatsd/Encoder.scala
+++ b/src/main/scala/github/gphat/censorinus/dogstatsd/Encoder.scala
@@ -46,7 +46,6 @@ object Encoder extends MetricEncoder {
     val finalValue = metric match {
       // This is the only string based-metric
       case nm: NumericMetric => {
-        System.out.println(nm.value)
         format.format(nm.value)
       }
       case sm: StringMetric => sm.value


### PR DESCRIPTION
I was seeing metric values appear in my log, and it occurred to me that this might be unintended. But feel free to close this PR if the `println` was meant to be there.