### PR TITLE
Updates for 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
 scala:
    - 2.11.12
-   - 2.12.4
+   - 2.12.10
+   - 2.13.1
 jdk:
   - oraclejdk8
   - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+dist: trusty
 scala:
    - 2.11.12
    - 2.12.10

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ organization := "com.github.gphat"
 
 name := "censorinus"
 
-scalaVersion := "2.12.4"
-crossScalaVersions := Seq("2.11.12", "2.12.4")
+scalaVersion := "2.13.1"
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 
 scalacOptions ++= Seq(
  "-encoding", "UTF-8",
@@ -11,22 +11,30 @@ scalacOptions ++= Seq(
  "-unchecked",
  "-deprecation",
  "-feature",
- "-Xfatal-warnings",
  // "-Xlint",
- "-Yno-adapted-args",
  "-Ywarn-dead-code",
  "-Ywarn-numeric-widen",
- "-Ywarn-value-discard",
- "-Xfuture",
- "-Ywarn-unused-import",
- "-Ypartial-unification"
-)
+ "-Ywarn-value-discard"
+ ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+   case Some((2, x)) if x <= 12 => Seq(
+     "-Yno-adapted-args",
+     "-Ywarn-unused-import",
+     "-Ypartial-unification",
+     "-Xfuture",
+     "-Xfatal-warnings",
+     "-Xsource:2.13"
+   )
+   case _ => Seq.empty
+ })
 
 resolvers ++= Seq("snapshots", "releases").map(Resolver.sonatypeRepo)
 
-libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.5" % Test
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.5" % Test
+libraryDependencies ++= Seq(
+  "org.scalactic" %% "scalactic" % "3.1.0" % Test,
+  "org.scalatest" %% "scalatest" % "3.1.0" % Test,
+  "org.scalatestplus" %% "scalacheck-1-14" % "3.1.0.0" % Test,
+  "org.scalacheck" %% "scalacheck" % "1.14.3" % Test
+)
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.3.5

--- a/src/main/scala/github/gphat/censorinus/Client.scala
+++ b/src/main/scala/github/gphat/censorinus/Client.scala
@@ -7,8 +7,9 @@ import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicLong
 import java.util.logging.Logger
 
-import scala.util.control.NonFatal
+import scala.collection.BufferedIterator
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 /** A Censorinus client! You should create one of these and reuse it across
   * your application.

--- a/src/test/scala/github/gphat/censorinus/ClientSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/ClientSpec.scala
@@ -3,11 +3,16 @@ package github.gphat.censorinus
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.{CountDownLatch, LinkedBlockingQueue, TimeUnit}
-import org.scalacheck.{Arbitrary, Gen}
+
+import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
 import github.gphat.censorinus.statsd.Encoder
 
 object TestSender {
@@ -45,7 +50,7 @@ class TestSender(val maxMessages: Int = Int.MaxValue) extends MetricSender {
   def shutdown: Unit = ()
 }
 
-class ClientSpec extends FlatSpec with Matchers with Eventually with GeneratorDrivenPropertyChecks {
+class ClientSpec extends AnyFlatSpec with Matchers with Eventually with ScalaCheckPropertyChecks {
 
   "ClientSpec" should "deal with gauges" in {
     val sender = new TestSender()

--- a/src/test/scala/github/gphat/censorinus/DogStatsDClientSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/DogStatsDClientSpec.scala
@@ -1,8 +1,10 @@
 package github.gphat.censorinus
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DogStatsDClientSpec extends FlatSpec with Matchers with BeforeAndAfter {
+class DogStatsDClientSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
 
   var client: DogStatsDClient = null
 

--- a/src/test/scala/github/gphat/censorinus/DogStatsDEncoderSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/DogStatsDEncoderSpec.scala
@@ -1,21 +1,24 @@
 package github.gphat.censorinus
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import github.gphat.censorinus.dogstatsd.Encoder
 
-class DogStatsDEncoderSpec extends FlatSpec with Matchers {
+class DogStatsDEncoderSpec extends AnyFlatSpec with Matchers {
 
   "DogStatsD Encoder" should "encode gauges" in {
 
-    val g = GaugeMetric(name = "foobar", value = 1.0, tags = Array("foo:bar"))
+    val g = GaugeMetric(name = "foobar", value = 1.0, tags = List("foo:bar"))
     Encoder.encode(g).get should be ("foobar:1|g|#foo:bar")
   }
 
   it should "drop infinite values" in {
-    val g1 = GaugeMetric(name = "foobar", value = java.lang.Double.NEGATIVE_INFINITY, tags = Array("foo:bar"))
+    val g1 = GaugeMetric(name = "foobar", value = java.lang.Double.NEGATIVE_INFINITY, tags = List("foo:bar"))
     Encoder.encode(g1) shouldBe None
 
-    val g2 = GaugeMetric(name = "foobar", value = java.lang.Double.POSITIVE_INFINITY, tags = Array("foo:bar"))
+    val g2 = GaugeMetric(name = "foobar", value = java.lang.Double.POSITIVE_INFINITY, tags = List("foo:bar"))
     Encoder.encode(g2) shouldBe None
   }
 
@@ -62,7 +65,7 @@ class DogStatsDEncoderSpec extends FlatSpec with Matchers {
   it should "encode service checks" in {
     val now = System.currentTimeMillis() / 1000L
     val m = ServiceCheckMetric(
-      name = "foobar", status = DogStatsDClient.SERVICE_CHECK_OK, tags = Array("foo:bar"),
+      name = "foobar", status = DogStatsDClient.SERVICE_CHECK_OK, tags = List("foo:bar"),
       hostname = Some("fart"), timestamp = Some(now), message = Some("wheeee")
     )
     Encoder.encode(m).get should be ("_sc|foobar|0|d:%d|h:fart|#foo:bar|m:wheeee".format(now))
@@ -71,7 +74,7 @@ class DogStatsDEncoderSpec extends FlatSpec with Matchers {
   it should "encode service checks with newlines" in {
     val now = System.currentTimeMillis() / 1000L
     val m = ServiceCheckMetric(
-      name = "foobar", status = DogStatsDClient.SERVICE_CHECK_OK, tags = Array("foo:bar"),
+      name = "foobar", status = DogStatsDClient.SERVICE_CHECK_OK, tags = List("foo:bar"),
       hostname = Some("fart"), timestamp = Some(now), message = Some("hello\nworld")
     )
     Encoder.encode(m).get should be ("_sc|foobar|0|d:%d|h:fart|#foo:bar|m:hello\\\\nworld".format(now))
@@ -80,7 +83,7 @@ class DogStatsDEncoderSpec extends FlatSpec with Matchers {
   it should "encode events" in {
     val now = System.currentTimeMillis() / 1000L
     val m = EventMetric(
-      name = "foobar", text = "derp derp derp", tags = Array("foo:bar"),
+      name = "foobar", text = "derp derp derp", tags = List("foo:bar"),
       hostname = Some("fart"), timestamp = Some(now), aggregationKey = Some("agg_key"),
       priority = Some(DogStatsDClient.EVENT_PRIORITY_LOW),
       sourceTypeName = Some("user"),
@@ -92,7 +95,7 @@ class DogStatsDEncoderSpec extends FlatSpec with Matchers {
   it should "encode events with newlines" in {
     val now = System.currentTimeMillis() / 1000L
     val m = EventMetric(
-      name = "foobar", text = "derp derp\nderp", tags = Array("foo:bar"),
+      name = "foobar", text = "derp derp\nderp", tags = List("foo:bar"),
       hostname = Some("fart"), timestamp = Some(now), aggregationKey = Some("agg_key"),
       priority = Some(DogStatsDClient.EVENT_PRIORITY_LOW),
       sourceTypeName = Some("user"),

--- a/src/test/scala/github/gphat/censorinus/SamplingSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/SamplingSpec.scala
@@ -1,9 +1,12 @@
 package github.gphat.censorinus
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import github.gphat.censorinus.statsd.Encoder
 
-class SamplingSpec extends FlatSpec with Matchers {
+class SamplingSpec extends AnyFlatSpec with Matchers {
 
   val s = new TestSender()
 

--- a/src/test/scala/github/gphat/censorinus/StatsDClientSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/StatsDClientSpec.scala
@@ -1,8 +1,10 @@
 package github.gphat.censorinus
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class StatsDClientSpec extends FlatSpec with Matchers with BeforeAndAfter {
+class StatsDClientSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
 
   var client: StatsDClient = null
 

--- a/src/test/scala/github/gphat/censorinus/StatsDEncoderSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/StatsDEncoderSpec.scala
@@ -1,9 +1,12 @@
 package github.gphat.censorinus
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import github.gphat.censorinus.statsd.Encoder
 
-class StatsDEncoderSpec extends FlatSpec with Matchers {
+class StatsDEncoderSpec extends AnyFlatSpec with Matchers {
 
   "StatsD Encoder" should "encode gauges" in {
 

--- a/src/test/scala/github/gphat/censorinus/SynchronySpec.scala
+++ b/src/test/scala/github/gphat/censorinus/SynchronySpec.scala
@@ -2,9 +2,12 @@ package github.gphat.censorinus
 
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import github.gphat.censorinus.statsd.Encoder
 
-class SynchronySpec extends FlatSpec with Matchers with Eventually {
+class SynchronySpec extends AnyFlatSpec with Matchers with Eventually {
 
   "Client" should "deal with gauges" in {
     val s = new TestSender(1)

--- a/src/test/scala/github/gphat/censorinus/UDPSenderSpec.scala
+++ b/src/test/scala/github/gphat/censorinus/UDPSenderSpec.scala
@@ -1,10 +1,13 @@
 package github.gphat.censorinus
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import java.nio.ByteBuffer
 import java.nio.channels.UnresolvedAddressException
 
-class UDPSenderSpec extends FlatSpec with Matchers {
+class UDPSenderSpec extends AnyFlatSpec with Matchers {
 
   "UDPSender" should "emit errors" in {
     // Guessing this port won't be used? :)


### PR DESCRIPTION
Mostly ScalaTest/ScalaCheck updates to versions that have been released for 2.13.